### PR TITLE
Implement ConnectionConfiguration that allows timeout and connectionName to be passed for a Connection

### DIFF
--- a/Sources/Examples/ConsumePublishServices/RabbitMqService.swift
+++ b/Sources/Examples/ConsumePublishServices/RabbitMqService.swift
@@ -19,7 +19,7 @@ struct RabbitMqService: Service {
         var tls = TLSConfiguration.makeClientConfiguration()
         tls.certificateVerification = .none
         connection = RetryingConnection(
-            connectionUrl, tls: tls, reconnectionInterval: .seconds(15), logger: logger
+            connectionUrl, configuration: .init(tls: tls), reconnectionInterval: .seconds(15), logger: logger
         )
     }
 

--- a/Sources/RabbitMq/Connection/Connection.swift
+++ b/Sources/RabbitMq/Connection/Connection.swift
@@ -1,6 +1,12 @@
 import AMQPClient
 import Logging
 
+/// Default timeout for a RabbitMQ connection to succeed.
+///
+/// The default in the base `rabbitmq-nio` library is also 60 seconds, but we define this
+/// as a `Duration` instead of a `TimeAmount`.
+public let DefaultConnectionTimeout = Duration.seconds(60)
+
 /// Default interval at which to poll a connection when using `waitForConnection()` or
 /// when monitoring the connection in `RetyingConnection`.
 ///

--- a/Sources/RabbitMq/Connection/ConnectionConfiguration.swift
+++ b/Sources/RabbitMq/Connection/ConnectionConfiguration.swift
@@ -1,0 +1,35 @@
+import NIOCore
+import NIOSSL
+
+/// Definition of configuration that can be provided for a RabbitMQ connection.
+public struct ConnectionConfiguration: Sendable {
+    /// If `nil` is passed, no TLS configuration will be used for the connection.
+    public var tls: TLSConfiguration?
+
+    /// The timeout for the connection to the broker to succeed.
+    public var timeout: Duration
+
+    /// The name or identification of the connection on the broker.
+    ///
+    /// If this is `nil`, the library will set the connection name to the value of `logger.label` instead.
+    public var connectionName: String?
+
+    /// Create the connection configuration.
+    ///
+    /// All fields use sensible defaults that work out of the box, but they can be customized
+    /// as needed.
+    ///
+    /// - Parameters:
+    ///   - tls: Optional `TLSConfiguration` to use for this connection. Defaults to `nil`.
+    ///   - timeout: Specify a timeout to use for this connection. Defaults to 60 seconds.
+    ///   - connectionName: Specify a name to use for this connection. Defaults to `nil`.
+    public init(
+        tls: TLSConfiguration? = nil,
+        timeout: Duration = DefaultConnectionTimeout,
+        connectionName: String? = nil
+    ) {
+        self.tls = tls
+        self.timeout = timeout
+        self.connectionName = connectionName
+    }
+}

--- a/Sources/RabbitMq/Extensions/AMQPConnection+initOptions.swift
+++ b/Sources/RabbitMq/Extensions/AMQPConnection+initOptions.swift
@@ -1,0 +1,41 @@
+import AMQPClient
+import Foundation
+import NIOCore
+import NIOSSL
+
+extension AMQPConnectionConfiguration.UrlScheme {
+    var defaultPort: Int {
+        switch self {
+        case .amqp: return 5672
+        case .amqps: return 5671
+        }
+    }
+}
+
+extension AMQPConnectionConfiguration {
+    init(url: String, tls: TLSConfiguration? = nil, timeout: TimeAmount, connectionName: String) throws {
+        guard let url = URL(string: url) else { throw AMQPConnectionError.invalidUrl }
+        guard let scheme = UrlScheme(rawValue: url.scheme ?? "") else { throw AMQPConnectionError.invalidUrlScheme }
+
+        // there is no such thing as a "" host
+        let host = url.host?.isEmpty == true ? nil : url.host
+        //special path magic for vhost interpretation (see https://www.rabbitmq.com/uri-spec.html)
+        var vhost = url.path.isEmpty ? nil : String(url.path.removingPercentEncoding?.dropFirst() ?? "")
+
+        // workaround: "/%f" is interpreted as / by URL (this restores %f as /)
+        if url.absoluteString.lowercased().hasSuffix("%2f") {
+            vhost = "/"
+        }
+
+        let server = Server(
+            host: host, port: url.port ?? scheme.defaultPort, user: url.user,
+            password: url.password?.removingPercentEncoding, vhost: vhost,
+            timeout: timeout, connectionName: connectionName
+        )
+
+        switch scheme {
+        case .amqp: self = .init(connection: .plain, server: server)
+        case .amqps: self = .init(connection: .tls(tls, sniServerName: nil), server: server)
+        }
+    }
+}


### PR DESCRIPTION
 - Had to specify a new `AMQPConnectionConfiguration` constructor to be able to pass the `timeout` and `connectionName`. I might try to PR to them to add this, since it would be useful for all.
 - The `timeout` defaults to 60 seconds and the `connectionName` defaults to `nil`. When `connectionName` is `nil`, the `logger.label` is used to identify the connection instead.